### PR TITLE
fix: allow falsy values in initial values

### DIFF
--- a/.changeset/rare-badgers-grow.md
+++ b/.changeset/rare-badgers-grow.md
@@ -1,0 +1,5 @@
+---
+"jotai-query-toolkit": patch
+---
+
+fix: allow falsy values in initial values

--- a/src/nextjs/use-query-initial-values.ts
+++ b/src/nextjs/use-query-initial-values.ts
@@ -19,9 +19,9 @@ import { hashQueryKey } from 'react-query';
 export function useQueryInitialValues(props?: Record<string, unknown>) {
   const queryKeys = props ? Object.keys(props) : [];
   const atoms = queryKeys.map(queryKey => {
-    const value = props ? props[queryKey] : null;
-    if (queryKey && !value)
+    if (queryKey && props && !(queryKey in props))
       throw Error(`[Jotai Query Toolkit] no initial data found for ${hashQueryKey(queryKey)}`);
+    const value = props ? props[queryKey] : null;
     return [initialDataAtom(queryKey), value] as const;
   });
   return [...atoms] as Iterable<readonly [Atom<unknown>, unknown]>;


### PR DESCRIPTION
I had a real head scratcher for some error when using micro-stacks-react. Turns out, the problem was that my query returned the value `0`, which threw a downstream error, because this code thought there was no initial value. My change only throws if the queryKey is not present - otherwise this allows all falsy values.